### PR TITLE
EOEPCA-279 Applied changes on the passport social #comment The issue …

### DIFF
--- a/static/extension/person_authentication/PassportExternalAuthenticator.py
+++ b/static/extension/person_authentication/PassportExternalAuthenticator.py
@@ -39,9 +39,9 @@ class PersonAuthentication(PersonAuthenticationType):
 
         self.extensionModule = self.loadExternalModule(configurationAttributes.get("extension_module"))
         extensionResult = self.extensionInit(configurationAttributes)
+        self.onBMail = str(configurationAttributes.get("mail_enable").getValue2())
         if extensionResult != None:
             return extensionResult
-
         print "Passport. init. Behaviour is social"
         success = self.processKeyStoreProperties(configurationAttributes)
 
@@ -551,7 +551,8 @@ class PersonAuthentication(PersonAuthenticationType):
                 print "Passport. attemptAuthentication. Updating user %s" % username
                 self.updateUser(userByUid, user_profile, userService)
             elif doAdd:
-                self.sendOnBoardingMail(email)
+                if self.onBMail is "True":
+                    self.sendOnBoardingMail(email)
                 print "Passport. attemptAuthentication. Creating user %s" % externalUid
                 newUser = self.addUser(externalUid, user_profile, userService)
                 username = newUser.getUserId()

--- a/templates/ldif/scripts.ldif
+++ b/templates/ldif/scripts.ldif
@@ -21,6 +21,7 @@ oxScript::%(person_authentication_usercertexternalauthenticator)s
 oxScriptType: person_authentication
 programmingLanguage: python
 
+
 dn: inum=2FDB-CF02,ou=scripts,o=gluu
 objectClass: oxCustomScript
 objectClass: top
@@ -30,6 +31,7 @@ oxEnabled: true
 inum: 2FDB-CF02
 oxConfigurationProperty: {"value1":"key_store_file","value2":"%(passport_rp_client_jks_fn)s","hide":false,"description":""}
 oxConfigurationProperty: {"value1":"key_store_password","value2":"%(passport_rp_client_jks_pass)s","hide":false,"description":""}
+oxConfigurationProperty: {"value1":"mail_enable","value2":"False","hide":false,"description":""}
 oxLevel: 40
 oxModuleProperty: {"value1":"usage_type","value2":"interactive","description":""}
 oxModuleProperty: {"value1":"location_type","value2":"ldap","description":""}
@@ -37,6 +39,8 @@ oxRevision: 1
 oxScript::%(person_authentication_passportexternalauthenticator)s
 oxScriptType: person_authentication
 programmingLanguage: python
+
+
 
 dn: inum=CB5B-3211,ou=scripts,o=gluu
 objectClass: oxCustomScript


### PR DESCRIPTION
…has been solved by making optional the SMTP Configuration through a custom property of the passport_social script. The new enable_mail must be set to True to check the SMTP functionallity. Also the SMTP Server configuration must be filled and tested, otherwise it will show the same error.